### PR TITLE
provision the minecraft server

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -42,7 +42,18 @@ cdk-deploy: require-venv
             --region {{AWS_REGION}} \
             --app "python3 app.py"
 
-cdk-destroy: require-venv
+cdk-diff: #require-venv
+    cd ./awscdk-minecraft/ \
+    && \
+        AWS_PROFILE={{AWS_PROFILE}} \
+        AWS_ACCOUNT_ID=$(just get-aws-account-id) \
+        CDK_DEFAULT_REGION={{AWS_REGION}} \
+        AWS_REGION={{AWS_REGION}} \
+        cdk diff \
+            --profile {{AWS_PROFILE}} \
+            --region {{AWS_REGION}} \
+            --app "python3 app.py"
+
     cd awscdk-minecraft \
     && \
         AWS_PROFILE={{AWS_PROFILE}} \

--- a/Justfile
+++ b/Justfile
@@ -64,7 +64,7 @@ cdk-diff: #require-venv
 # generate CloudFormation from the code in "awscdk-minecraft"
 cdk-synth: require-venv login-to-aws
     cd awscdk-minecraft \
-    && cdk synth --all --profile mlops-club
+    && cdk synth --all --profile mlops-club --app "python3 app.py"
 
 open-aws:
     #!/bin/bash

--- a/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/.dockerignore
+++ b/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/.dockerignore
@@ -5,3 +5,4 @@
 !setup.py
 !pyproject.toml
 !README.md
+!resources/

--- a/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/Dockerfile
+++ b/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/Dockerfile
@@ -2,7 +2,7 @@
 # References
 # - AWS CLI https://levelup.gitconnected.com/how-to-create-a-simple-docker-image-with-aws-cli-and-serverless-installed-d1cc2901946
 
-FROM alpine:3.16.2
+FROM --platform=linux/amd64 alpine:3.16.2
 
 # Install packages
 RUN apk update && apk add --update --no-cache \

--- a/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/Dockerfile
+++ b/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/Dockerfile
@@ -25,7 +25,7 @@ RUN npm update -g
 RUN pip install --upgrade pip && \
     pip install --upgrade awscli
 # Install cdk
-RUN npm install -g aws-cdk
+RUN npm install -g aws-cdk@2.54.0
 RUN cdk --version
 
 WORKDIR /app

--- a/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/app.py
+++ b/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/app.py
@@ -1,11 +1,19 @@
 """Entrypoint for the AWS CDK Minecraft Server Deployer."""
+
 import os
 
 from aws_cdk import App, Environment
 from minecraft_server_deployer import ServerStack
 
-# for development, use account/region from cdk cli
-CDK_ENV = Environment(account=os.environ["AWS_ACCOUNT_ID"], region=os.getenv("AWS_REGION"))
+AWS_REGION = os.environ["AWS_REGION"]
+AWS_ACCOUNT_ID = os.environ["AWS_ACCOUNT_ID"]
+
+from datetime import datetime
+
+print(f"[{datetime.now()}] Running app.py for Account {AWS_ACCOUNT_ID}, Region {AWS_REGION}")
+
+# for development, use account/region from CDK CLI
+CDK_ENV = Environment(account=AWS_ACCOUNT_ID, region=AWS_REGION)
 APP = App()
 
 ServerStack(APP, "awscdk-minecraft-server", env=CDK_ENV)

--- a/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/app.py
+++ b/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/app.py
@@ -1,14 +1,15 @@
 """Entrypoint for the AWS CDK Minecraft Server Deployer."""
 
 import os
+from datetime import datetime
 
 from aws_cdk import App, Environment
 from minecraft_server_deployer import ServerStack
 
 AWS_REGION = os.environ["AWS_REGION"]
 AWS_ACCOUNT_ID = os.environ["AWS_ACCOUNT_ID"]
+MINECRAFT_SERVER_VERSION = os.environ.get("MINECRAFT_SERVER_VERSION", "1.19.3")
 
-from datetime import datetime
 
 print(f"[{datetime.now()}] Running app.py for Account {AWS_ACCOUNT_ID}, Region {AWS_REGION}")
 
@@ -16,6 +17,6 @@ print(f"[{datetime.now()}] Running app.py for Account {AWS_ACCOUNT_ID}, Region {
 CDK_ENV = Environment(account=AWS_ACCOUNT_ID, region=AWS_REGION)
 APP = App()
 
-ServerStack(APP, "awscdk-minecraft-server", env=CDK_ENV)
+ServerStack(APP, "awscdk-minecraft-server", minecraft_server_version=MINECRAFT_SERVER_VERSION, env=CDK_ENV)
 
 APP.synth()

--- a/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/docker-compose.yml
+++ b/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/docker-compose.yml
@@ -4,7 +4,9 @@ services:
 
   cdk:
     image: mlops-club/cdk-server-deployer
-    command: cdk deploy --app 'python3 app.py' --require-approval=never
+    # command: cdk synth
+    command: cdk synth '*' --profile mlops-club --app 'python3 app.py'
+    # command: cdk deploy --app 'python3 app.py' --require-approval=never
     env_file:
       - .env
     environment:

--- a/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/docker-compose.yml
+++ b/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/docker-compose.yml
@@ -4,11 +4,14 @@ services:
 
   cdk:
     image: mlops-club/cdk-server-deployer
-    command: cdk deploy --app 'python3 app.py'
+    command: cdk deploy --app 'python3 app.py' --require-approval=never
     env_file:
       - .env
     environment:
       AWS_REGION: us-west-2
+      AWS_ACCOUNT_ID: "630013828440"
     build:
       context: .
       dockerfile: ./Dockerfile
+    # volumes:
+    #   - .:/app

--- a/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/docker-compose.yml
+++ b/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/docker-compose.yml
@@ -5,8 +5,8 @@ services:
   cdk:
     image: mlops-club/cdk-server-deployer
     # command: cdk synth
-    command: cdk synth '*' --profile mlops-club --app 'python3 app.py'
-    # command: cdk deploy --app 'python3 app.py' --require-approval=never
+    # command: cdk synth '*' --app 'python3 app.py'
+    command: cdk deploy --app 'python3 app.py' --require-approval=never
     env_file:
       - .env
     environment:

--- a/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/resources/user-data.sh
+++ b/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/resources/user-data.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# print the commands this script runs as they are executed
+set -x
+
+#########################################
+# --- Install CLI tool dependencies --- #
+#########################################
+
+yum update -y
+yum install -y docker
+
+# install docker-compose and make the binary executable
+curl -L https://github.com/docker/compose/releases/latest/download/docker-compose-$$(uname -s)-$$(uname -m) -o /usr/bin/docker-compose
+chmod +x /usr/bin/docker-compose
+
+# initialize docker and docker-swarm daemons
+service docker start
+docker swarm init
+
+# install aws cli
+yum install -y python3
+pip3 install awscli --upgrade --user
+
+# prepare a docker-compose.yml that runs the
+cat << EOF > /home/ec2-user/docker-compose.yml
+version: '3.7'
+services:
+    minecraft:
+        image: itzg/minecraft-server
+        restart: always
+        ports:
+            - 25565:25565
+        environment:
+            EULA: "TRUE"
+            VERSION: "$MINECRAFT_SERVER_SEMANTIC_VERSION"
+        networks:
+        - minecraft-server
+        deploy:
+            replicas: 1
+EOF
+
+
+##########################################
+# --- Start up the with docker swarm --- #
+##########################################
+
+cd /home/ec2-user
+
+# create a docker stack
+docker network create minecraft-server
+docker stack deploy -c docker-compose.yml minecraft
+
+chmod +x /home/ec2-user/setup.sh
+/home/ec2-user/setup.sh

--- a/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/resources/user-data.sh
+++ b/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/resources/user-data.sh
@@ -38,6 +38,11 @@ services:
         - minecraft-server
         deploy:
             replicas: 1
+
+networks:
+    minecraft-server:
+        driver: overlay
+        name: minecraft-server
 EOF
 
 
@@ -48,7 +53,7 @@ EOF
 cd /home/ec2-user
 
 # create a docker stack
-docker network create minecraft-server
+# docker network create minecraft-server
 docker stack deploy -c docker-compose.yml minecraft
 
 chmod +x /home/ec2-user/setup.sh

--- a/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/setup.cfg
+++ b/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/setup.cfg
@@ -35,7 +35,7 @@ test_suite = tests/unit_tests
 python_requires =  >= 3.6.*
 install_requires =
     importlib-metadata; python_version<"3.8"
-    aws-cdk-lib >=2.45.0, <3.0.0
+    aws-cdk-lib >=2.54.0, <3.0.0
     constructs >=10.0.5, <11.0.0
     aws-cdk.aws-batch-alpha
 

--- a/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/src/minecraft_server_deployer/server_stack.py
+++ b/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/src/minecraft_server_deployer/server_stack.py
@@ -2,6 +2,7 @@
 
 
 from aws_cdk import Stack
+from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_s3 as s3
 from constructs import Construct
 
@@ -24,7 +25,67 @@ class ServerStack(Stack):
         The bucket where the server files will be stored.
     """
 
-    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
+    def __init__(self, scope: Construct, construct_id: str, version="1.19.3", **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
-        s3.Bucket(self, "MinecraftServer")
+        s3.Bucket(scope=self, id="MinecraftServer")
+
+        # set up an ec2 instance from an aws linux AMI and run a setup.sh script upon startup.
+        _vpc = ec2.Vpc.from_lookup(scope=self, is_default=True, id="defaultVpc")
+
+        _sg = ec2.SecurityGroup(
+            scope=self,
+            id="MinecraftServerInstanceSecurityGroup",
+            vpc=_vpc,
+            allow_all_outbound=True,
+        )
+        _sg.add_ingress_rule(
+            peer=ec2.Peer.any_ipv4(),
+            connection=ec2.Port.tcp(25565),
+            description="Allow inbound traffic on port 25565",
+        )
+        _sg.add_ingress_rule(
+            peer=ec2.Peer.any_ipv4(),
+            connection=ec2.Port.tcp(22),
+            description="Allow inbound traffic on port 22",
+        )
+
+        ec2.Instance(
+            scope=self,
+            id="MinecraftServerInstance",
+            vpc=_vpc,
+            instance_type=ec2.InstanceType("t2.medium"),
+            machine_image=ec2.MachineImage.latest_amazon_linux(),
+            user_data=ec2.UserData.custom(
+                f"""#!/bin/bash
+                sudo yum update -y
+                sudo yum install -y docker docker-compose
+                sudo service docker start
+
+                cat EOF > /home/ec2-user/docker-compose.yml
+                version: '3.7'
+                services:
+                    minecraft:
+                        container_name: mc
+                        image: itzg/minecraft-server
+                        ports:
+                            - 25565:25565
+                        environment:
+                            EULA: "TRUE"
+                            VERSION: "{version}"
+
+                EOF
+
+                cat EOF > /home/ec2-user/setup.sh
+                #!/bin/bash
+                sudo docker-compose up -d
+                EOF
+
+                sudo chmod +x /home/ec2-user/setup.sh
+                sudo /home/ec2-user/setup.sh
+                """
+            ),
+            # add security group to allow inbound traffic on port 25565
+            # allow console access for debugging
+            security_group=_sg,
+        )

--- a/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/src/minecraft_server_deployer/server_stack.py
+++ b/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/src/minecraft_server_deployer/server_stack.py
@@ -48,7 +48,6 @@ def add_alarms_to_stack(scope: Construct, ec2_instance_id: str) -> None:
     Returns
     -------
     None
-
     """
     cloudwatch.Alarm(
         scope=scope,

--- a/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/src/minecraft_server_deployer/server_stack.py
+++ b/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/src/minecraft_server_deployer/server_stack.py
@@ -85,7 +85,5 @@ class ServerStack(Stack):
                 sudo /home/ec2-user/setup.sh
                 """
             ),
-            # add security group to allow inbound traffic on port 25565
-            # allow console access for debugging
             security_group=_sg,
         )

--- a/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/src/minecraft_server_deployer/server_stack.py
+++ b/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/src/minecraft_server_deployer/server_stack.py
@@ -35,6 +35,107 @@ def render_user_data_script(minecraft_semantic_version: str) -> str:
     )
 
 
+def add_alarms_to_stack(scope: Construct, ec2_instance_id: str) -> None:
+    """Add alarms to the stack.
+
+    Parameters
+    ----------
+    scope : Construct
+        The scope of the stack.
+    ec2_instance_id : str
+        The ID of the EC2 instance to monitor.
+
+    Returns
+    -------
+    None
+
+    """
+    cloudwatch.Alarm(
+        scope=scope,
+        id="MinecraftServerCpuAlarm",
+        metric=cloudwatch.Metric(
+            namespace="AWS/EC2",
+            metric_name="CPUUtilization",
+            dimensions_map={"InstanceId": ec2_instance_id},
+            statistic="Average",
+            period=cdk.Duration.minutes(1),
+        ),
+        comparison_operator=cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+        threshold=80,
+        evaluation_periods=1,
+        treat_missing_data=cloudwatch.TreatMissingData.NOT_BREACHING,
+        alarm_description="Alarm if CPU usage is greater than 80% for 1 minute",
+    )
+
+    cloudwatch.Alarm(
+        scope=scope,
+        id="MinecraftServerMemoryAlarm",
+        metric=cloudwatch.Metric(
+            namespace="System/Linux",
+            metric_name="MemoryUtilization",
+            dimensions_map={"InstanceId": ec2_instance_id},
+            statistic="Average",
+            period=cdk.Duration.minutes(1),
+        ),
+        comparison_operator=cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+        threshold=80,
+        evaluation_periods=1,
+        treat_missing_data=cloudwatch.TreatMissingData.NOT_BREACHING,
+        alarm_description="Alarm if memory usage is greater than 80% for 1 minute",
+    )
+
+    cloudwatch.Alarm(
+        scope=scope,
+        id="MinecraftServerDiskAlarm",
+        metric=cloudwatch.Metric(
+            namespace="System/Linux",
+            metric_name="DiskSpaceUtilization",
+            dimensions_map={"InstanceId": ec2_instance_id},
+            statistic="Average",
+            period=cdk.Duration.minutes(1),
+        ),
+        comparison_operator=cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+        threshold=80,
+        evaluation_periods=1,
+        treat_missing_data=cloudwatch.TreatMissingData.NOT_BREACHING,
+        alarm_description="Alarm if disk usage is greater than 80% for 1 minute",
+    )
+
+    cloudwatch.Alarm(
+        scope=scope,
+        id="MinecraftServerNetworkAlarm",
+        metric=cloudwatch.Metric(
+            namespace="System/Linux",
+            metric_name="NetworkIn",
+            dimensions_map={"InstanceId": ec2_instance_id},
+            statistic="Average",
+            period=cdk.Duration.minutes(1),
+        ),
+        comparison_operator=cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+        threshold=80,
+        evaluation_periods=1,
+        treat_missing_data=cloudwatch.TreatMissingData.NOT_BREACHING,
+        alarm_description="Alarm if network usage is greater than 80% for 1 minute",
+    )
+
+    cloudwatch.Alarm(
+        scope=scope,
+        id="MinecraftServerOpenConnectionsAlarm",
+        metric=cloudwatch.Metric(
+            namespace="System/Linux",
+            metric_name="NetworkIn",
+            dimensions_map={"InstanceId": ec2_instance_id},
+            statistic="Average",
+            period=cdk.Duration.minutes(1),
+        ),
+        comparison_operator=cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+        threshold=80,
+        evaluation_periods=1,
+        treat_missing_data=cloudwatch.TreatMissingData.NOT_BREACHING,
+        alarm_description="Alarm if number of open connections is greater than 80% for 1 minute",
+    )
+
+
 class ServerStack(Stack):
     """Stack responsible for creating the running minecraft server on AWS.
 
@@ -111,87 +212,12 @@ class ServerStack(Stack):
             security_group=_sg,
         )
 
-        cloudwatch.Alarm(
+        # add stack output for ip address of the ec2 instance
+        cdk.CfnOutput(
             scope=self,
-            id="MinecraftServerCpuAlarm",
-            metric=cloudwatch.Metric(
-                namespace="AWS/EC2",
-                metric_name="CPUUtilization",
-                dimensions={"InstanceId": _ec2.instance_id},
-                statistic="Average",
-                period=cdk.Duration.minutes(1),
-            ),
-            comparison_operator=cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
-            threshold=80,
-            evaluation_periods=1,
-            treat_missing_data=cloudwatch.TreatMissingData.NOT_BREACHING,
-            alarm_description="Alarm if CPU usage is greater than 80% for 1 minute",
+            id="MinecraftServerIp",
+            value=_ec2.instance_public_ip,
+            description="The public IP address of the Minecraft server",
         )
 
-        cloudwatch.Alarm(
-            scope=self,
-            id="MinecraftServerMemoryAlarm",
-            metric=cloudwatch.Metric(
-                namespace="System/Linux",
-                metric_name="MemoryUtilization",
-                dimensions={"InstanceId": _ec2.instance_id},
-                statistic="Average",
-                period=cdk.Duration.minutes(1),
-            ),
-            comparison_operator=cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
-            threshold=80,
-            evaluation_periods=1,
-            treat_missing_data=cloudwatch.TreatMissingData.NOT_BREACHING,
-            alarm_description="Alarm if memory usage is greater than 80% for 1 minute",
-        )
-
-        cloudwatch.Alarm(
-            scope=self,
-            id="MinecraftServerDiskAlarm",
-            metric=cloudwatch.Metric(
-                namespace="System/Linux",
-                metric_name="DiskSpaceUtilization",
-                dimensions={"InstanceId": _ec2.instance_id},
-                statistic="Average",
-                period=cdk.Duration.minutes(1),
-            ),
-            comparison_operator=cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
-            threshold=80,
-            evaluation_periods=1,
-            treat_missing_data=cloudwatch.TreatMissingData.NOT_BREACHING,
-            alarm_description="Alarm if disk usage is greater than 80% for 1 minute",
-        )
-
-        cloudwatch.Alarm(
-            scope=self,
-            id="MinecraftServerNetworkAlarm",
-            metric=cloudwatch.Metric(
-                namespace="System/Linux",
-                metric_name="NetworkIn",
-                dimensions={"InstanceId": _ec2.instance_id},
-                statistic="Average",
-                period=cdk.Duration.minutes(1),
-            ),
-            comparison_operator=cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
-            threshold=80,
-            evaluation_periods=1,
-            treat_missing_data=cloudwatch.TreatMissingData.NOT_BREACHING,
-            alarm_description="Alarm if network usage is greater than 80% for 1 minute",
-        )
-
-        cloudwatch.Alarm(
-            scope=self,
-            id="MinecraftServerOpenConnectionsAlarm",
-            metric=cloudwatch.Metric(
-                namespace="System/Linux",
-                metric_name="NetworkIn",
-                dimensions={"InstanceId": _ec2.instance_id},
-                statistic="Average",
-                period=cdk.Duration.minutes(1),
-            ),
-            comparison_operator=cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
-            threshold=80,
-            evaluation_periods=1,
-            treat_missing_data=cloudwatch.TreatMissingData.NOT_BREACHING,
-            alarm_description="Alarm if number of open connections is greater than 80% for 1 minute",
-        )
+        add_alarms_to_stack(scope=self, ec2_instance_id=_ec2.instance_id)

--- a/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/src/minecraft_server_deployer/server_stack.py
+++ b/awscdk-minecraft/resources/awscdk-minecraft-server-deployer/src/minecraft_server_deployer/server_stack.py
@@ -3,6 +3,7 @@
 
 from aws_cdk import Stack
 from aws_cdk import aws_ec2 as ec2
+from aws_cdk import aws_iam as iam
 from aws_cdk import aws_s3 as s3
 from constructs import Construct
 
@@ -30,12 +31,12 @@ class ServerStack(Stack):
 
         s3.Bucket(scope=self, id="MinecraftServer")
 
-        # set up an ec2 instance from an aws linux AMI and run a setup.sh script upon startup.
         _vpc = ec2.Vpc.from_lookup(scope=self, is_default=True, id="defaultVpc")
 
+        # set up security group to allow inbound traffic on port 25565 for anyone
         _sg = ec2.SecurityGroup(
             scope=self,
-            id="MinecraftServerInstanceSecurityGroup",
+            id="MinecraftServerSecurityGroup",
             vpc=_vpc,
             allow_all_outbound=True,
         )
@@ -49,6 +50,19 @@ class ServerStack(Stack):
             connection=ec2.Port.tcp(22),
             description="Allow inbound traffic on port 22",
         )
+        # allow all outbound traffic
+        _sg.add_egress_rule(
+            peer=ec2.Peer.any_ipv4(),
+            connection=ec2.Port.all_traffic(),
+            description="Allow all outbound traffic",
+        )
+
+        # create iam role for ec2 instance
+        _iam_role = iam.Role(
+            scope=self,
+            id="MinecraftServerIamRole",
+            assumed_by=iam.ServicePrincipal("ec2.amazonaws.com"),
+        )
 
         ec2.Instance(
             scope=self,
@@ -58,10 +72,6 @@ class ServerStack(Stack):
             machine_image=ec2.MachineImage.latest_amazon_linux(),
             user_data=ec2.UserData.custom(
                 f"""#!/bin/bash
-                sudo yum update -y
-                sudo yum install -y docker docker-compose
-                sudo service docker start
-
                 cat EOF > /home/ec2-user/docker-compose.yml
                 version: '3.7'
                 services:
@@ -78,12 +88,30 @@ class ServerStack(Stack):
 
                 cat EOF > /home/ec2-user/setup.sh
                 #!/bin/bash
+                sudo yum update -y
+                sudo yum install -y docker docker-compose
+                sudo service docker start
+
+                # install ssm agent
+                sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+                sudo systemctl enable amazon-ssm-agent
+                sudo systemctl start amazon-ssm-agent
+                # install aws cli
+                sudo yum install -y python3
+                sudo pip3 install awscli --upgrade --user
+                # install aws s3 sync
+                sudo yum install -y s3fs-fuse
+
+                cd /home/ec2-user && \
                 sudo docker-compose up -d
+
                 EOF
 
                 sudo chmod +x /home/ec2-user/setup.sh
                 sudo /home/ec2-user/setup.sh
                 """
             ),
+            user_data_causes_replacement=True,
+            role=_iam_role,
             security_group=_sg,
         )

--- a/awscdk-minecraft/src/cdk_minecraft/deploy_server_batch_job/job_definition.py
+++ b/awscdk-minecraft/src/cdk_minecraft/deploy_server_batch_job/job_definition.py
@@ -1,6 +1,7 @@
 """Job definition for the batch job that will deploy the Minecraft server on EC2."""
 from pathlib import Path
 
+from aws_cdk import Stack
 from aws_cdk import aws_batch_alpha as batch_alpha
 from aws_cdk import aws_ecr_assets as ecr_assets
 from aws_cdk import aws_ecs as ecs
@@ -9,12 +10,6 @@ from constructs import Construct
 
 THIS_DIR = Path(__file__).parent
 DOCKERIZED_AWS_CDK_BUILD_CONTEXT = (THIS_DIR / "../../../resources/awscdk-minecraft-server-deployer").resolve()
-
-# class ExampleStack(Construct):
-#     def __init__(
-#         self, scope: Construct, construct_id: str, **kwargs
-#     ) -> None:
-#         super().__init__(scope, construct_id, **kwargs)
 
 
 def make_minecraft_ec2_deployment__batch_job_definition(
@@ -38,6 +33,8 @@ def make_minecraft_ec2_deployment__batch_job_definition(
     execution_role: iam.Role = make_batch_execution_role(scope=scope, id_prefix=id_prefix)
     job_role: iam.Role = make_cdk_deployment_role(scope=scope, id_prefix=id_prefix)
 
+    stack = Stack.of(scope)
+
     return batch_alpha.JobDefinition(
         scope=scope,
         id=f"{id_prefix}CdkMinecraftEc2DeploymentJD",
@@ -46,12 +43,24 @@ def make_minecraft_ec2_deployment__batch_job_definition(
                 directory=str(DOCKERIZED_AWS_CDK_BUILD_CONTEXT),
                 platform=ecr_assets.Platform.LINUX_AMD64,
             ),
-            command=["cdk", "deploy", "--app", "'python3 /app/app.py'"],
+            command=["cdk", "deploy", "--app", "'python3 /app/app.py'", "--require-approval=never"],
             job_role=job_role,
             execution_role=execution_role,
             log_configuration=batch_alpha.LogConfiguration(
                 log_driver=batch_alpha.LogDriver.AWSLOGS,
+                options={
+                    # With the awslogs-group option, you can specify the log group that the awslogs log driver
+                    # sends its log streams to. If this isn't specified, aws/batch/job is used.
+                    "awslogs-group": "minecraft-server-deployment-job",
+                    # Specify whether you want the log group automatically created. If this option isn't specified, it defaults to false.
+                    "awslogs-create-group": "true",
+                },
             ),
+            assign_public_ip=True,
+            environment={
+                "AWS_ACCOUNT_ID": stack.account,
+                "AWS_REGION": stack.region,
+            },
         ),
         platform_capabilities=[batch_alpha.PlatformCapabilities.FARGATE],
     )
@@ -118,8 +127,70 @@ def make_batch_execution_role(scope: Construct, id_prefix: str) -> iam.Role:
                                 "ecr:BatchCheckLayerAvailability",
                                 "ecr:GetDownloadUrlForLayer",
                                 "ecr:BatchGetImage",
+                                # "logs:CreateLogStream",
+                                # "logs:PutLogEvents",
+                                # from AWS docs
+                                "ec2:DescribeAccountAttributes",
+                                "ec2:DescribeInstances",
+                                "ec2:DescribeInstanceAttribute",
+                                "ec2:DescribeSubnets",
+                                "ec2:DescribeSecurityGroups",
+                                "ec2:DescribeKeyPairs",
+                                "ec2:DescribeImages",
+                                "ec2:DescribeImageAttribute",
+                                "ec2:DescribeInstanceStatus",
+                                "ec2:DescribeSpotInstanceRequests",
+                                "ec2:DescribeSpotFleetInstances",
+                                "ec2:DescribeSpotFleetRequests",
+                                "ec2:DescribeSpotPriceHistory",
+                                "ec2:DescribeVpcClassicLink",
+                                "ec2:DescribeLaunchTemplateVersions",
+                                "ec2:CreateLaunchTemplate",
+                                "ec2:DeleteLaunchTemplate",
+                                "ec2:RequestSpotFleet",
+                                "ec2:CancelSpotFleetRequests",
+                                "ec2:ModifySpotFleetRequest",
+                                "ec2:TerminateInstances",
+                                "ec2:RunInstances",
+                                "autoscaling:DescribeAccountLimits",
+                                "autoscaling:DescribeAutoScalingGroups",
+                                "autoscaling:DescribeLaunchConfigurations",
+                                "autoscaling:DescribeAutoScalingInstances",
+                                "autoscaling:CreateLaunchConfiguration",
+                                "autoscaling:CreateAutoScalingGroup",
+                                "autoscaling:UpdateAutoScalingGroup",
+                                "autoscaling:SetDesiredCapacity",
+                                "autoscaling:DeleteLaunchConfiguration",
+                                "autoscaling:DeleteAutoScalingGroup",
+                                "autoscaling:CreateOrUpdateTags",
+                                "autoscaling:SuspendProcesses",
+                                "autoscaling:PutNotificationConfiguration",
+                                "autoscaling:TerminateInstanceInAutoScalingGroup",
+                                "ecs:DescribeClusters",
+                                "ecs:DescribeContainerInstances",
+                                "ecs:DescribeTaskDefinition",
+                                "ecs:DescribeTasks",
+                                "ecs:ListAccountSettings",
+                                "ecs:ListClusters",
+                                "ecs:ListContainerInstances",
+                                "ecs:ListTaskDefinitionFamilies",
+                                "ecs:ListTaskDefinitions",
+                                "ecs:ListTasks",
+                                "ecs:CreateCluster",
+                                "ecs:DeleteCluster",
+                                "ecs:RegisterTaskDefinition",
+                                "ecs:DeregisterTaskDefinition",
+                                "ecs:RunTask",
+                                "ecs:StartTask",
+                                "ecs:StopTask",
+                                "ecs:UpdateContainerAgent",
+                                "ecs:DeregisterContainerInstance",
+                                "logs:CreateLogGroup",
                                 "logs:CreateLogStream",
                                 "logs:PutLogEvents",
+                                "logs:DescribeLogGroups",
+                                "iam:GetInstanceProfile",
+                                "iam:GetRole",
                             ],
                             "Resource": "*",
                         }

--- a/awscdk-minecraft/src/cdk_minecraft/deploy_server_batch_job/job_definition.py
+++ b/awscdk-minecraft/src/cdk_minecraft/deploy_server_batch_job/job_definition.py
@@ -61,6 +61,8 @@ def make_minecraft_ec2_deployment__batch_job_definition(
                 "AWS_ACCOUNT_ID": stack.account,
                 "AWS_REGION": stack.region,
             },
+            vcpus=1,
+            memory_limit_mib=2 * 1024,
         ),
         platform_capabilities=[batch_alpha.PlatformCapabilities.FARGATE],
     )

--- a/awscdk-minecraft/src/cdk_minecraft/deploy_server_batch_job/state_machine.py
+++ b/awscdk-minecraft/src/cdk_minecraft/deploy_server_batch_job/state_machine.py
@@ -1,0 +1,319 @@
+from pathlib import Path
+from typing import Literal
+
+from aws_cdk import aws_stepfunctions as sfn
+from aws_cdk import aws_stepfunctions_tasks as sfn_tasks
+from constructs import Construct
+
+THIS_DIR = Path(__file__).parent
+
+
+class ProvisionMinecraftServerStateMachine(Construct):
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        job_queue_arn: str,
+        deploy_or_destroy_mc_server_job_definition_arn: str,
+        **kwargs,
+    ) -> None:
+        """
+
+        {
+            "command": "destroy"
+        }
+        """
+        super().__init__(scope, construct_id, **kwargs)
+        self.namer = lambda name: f"{construct_id}-{name}"
+
+        submit_cdk_deploy_batch_job: sfn_tasks.BatchSubmitJob = (
+            create__deploy_or_destroy__submit_batch_job_state(
+                scope=self,
+                command="deploy",
+                id_prefix=construct_id,
+                job_queue_arn=job_queue_arn,
+                deploy_or_destroy_mc_server_job_definition_arn=deploy_or_destroy_mc_server_job_definition_arn,
+            )
+        )
+
+        submit_cdk_destroy_batch_job: sfn_tasks.BatchSubmitJob = (
+            create__deploy_or_destroy__submit_batch_job_state(
+                scope=self,
+                command="destroy",
+                id_prefix=construct_id,
+                job_queue_arn=job_queue_arn,
+                deploy_or_destroy_mc_server_job_definition_arn=deploy_or_destroy_mc_server_job_definition_arn,
+            )
+        )
+
+        state_machine = (
+            sfn.Choice(
+                self,
+                id=self.namer("ChooseCdkDeployOrDestroy"),
+            )
+            .when(
+                condition=sfn.Condition.string_equals("$.command", "deploy"), next=submit_cdk_deploy_batch_job
+            )
+            .when(
+                condition=sfn.Condition.string_equals("$.command", "destroy"),
+                next=submit_cdk_destroy_batch_job,
+            )
+        )
+
+        self.state_machine = sfn.StateMachine(
+            scope=self,
+            id=self.namer("StateMachine"),
+            definition=state_machine,
+            # logs=sfn.LogOptions(),
+            role=None,
+        )
+
+
+def create__deploy_or_destroy__submit_batch_job_state(
+    scope: Construct,
+    id_prefix: str,
+    command: Literal["deploy", "destroy"],
+    job_queue_arn: str,
+    deploy_or_destroy_mc_server_job_definition_arn: str,
+) -> sfn_tasks.BatchSubmitJob:
+
+    if command == "deploy":
+        return sfn_tasks.BatchSubmitJob(
+            scope=scope,
+            id=f"{id_prefix}CdkDeployMcServerBatchJob",
+            job_name=f"{id_prefix}DeployMinecraftServer",
+            container_overrides=sfn_tasks.BatchContainerOverrides(
+                environment=None,
+                command=["cdk", "deploy", "--app", "'python3 /app/app.py'", "--require-approval=never"],
+            ),
+            job_queue_arn=job_queue_arn,
+            job_definition_arn=deploy_or_destroy_mc_server_job_definition_arn,
+        )
+
+    if command == "destroy":
+        return sfn_tasks.BatchSubmitJob(
+            scope=scope,
+            id=f"{id_prefix}CdkDestroyMcServerBatchJob",
+            job_name=f"{id_prefix}DestroyMinecraftServer",
+            container_overrides=sfn_tasks.BatchContainerOverrides(
+                environment=None,
+                command=["cdk", "destroy", "--app", "'python3 /app/app.py'", "--force"],
+            ),
+            job_queue_arn=job_queue_arn,
+            job_definition_arn=deploy_or_destroy_mc_server_job_definition_arn,
+        )
+
+    raise ValueError("Invalid command. ``command`` must be one of 'destroy' or 'deploy'")
+
+    # def make_state_machine(
+    #     self,
+    #     customer_org_name: str,
+    #     datalake_bucket_name: str,
+    #     etl_function: lambda_.Function,
+    #     s3_folder_deleter_function: lambda_.Function,
+    # ) -> sfn.StateMachine:
+    #     """Create the state machine (DAG) that does the ETL."""
+    #     state_machine = sfn.StateMachine(
+    #         self,
+    #         self.namer("etl-state-machine"),
+    #         definition=self.make__state_machine_definition(
+    #             customer_org_name=customer_org_name,
+    #             datalake_bucket_name=datalake_bucket_name,
+    #             etl_function=etl_function,
+    #             s3_folder_deleter_function=s3_folder_deleter_function,
+    #         ),
+    #     )
+
+    #     self.grant_permissions_to_state_machine(
+    #         state_machine_role=state_machine.role,
+    #         datalake_bucket_name=datalake_bucket_name,
+    #     )
+
+    #     return state_machine
+
+    # def make__state_machine_definition(
+    #     self,
+    #     customer_org_name: str,
+    #     datalake_bucket_name: str,
+    #     etl_function: lambda_.Function,
+    #     s3_folder_deleter_function: lambda_.Function,
+    # ) -> sfn.IChainable:
+    #     """Define the entire DAG of states/tasks that will ELT data for a customer."""
+    #     etl_chain = self.make_customer_etl_chain(
+    #         customer_org_name=customer_org_name,
+    #         datalake_bucket_name=datalake_bucket_name,
+    #         etl_lambda=etl_function,
+    #         s3_folder_deleter_lambda=s3_folder_deleter_function,
+    #     )
+
+    #     pillar_one_chain = self.make__pillar_one_query__state(
+    #         customer_org_name=customer_org_name,
+    #         datalake_bucket_name=datalake_bucket_name,
+    #         s3_folder_deleter_lambda=s3_folder_deleter_function,
+    #     )
+
+    #     opportunity_field_history_chain = self.make__opportunity_field_history__state(
+    #         customer_org_name=customer_org_name,
+    #         datalake_bucket_name=datalake_bucket_name,
+    #         s3_folder_deleter_lambda=s3_folder_deleter_function,
+    #     )
+
+    #     post_clean_queries_parallel = sfn.Parallel(
+    #         self,
+    #         self.namer("post-clean-queries"),
+    #     )
+
+    #     post_clean_queries_parallel.branch(pillar_one_chain)
+    #     post_clean_queries_parallel.branch(opportunity_field_history_chain)
+
+    #     return etl_chain.next(post_clean_queries_parallel)
+
+    # def make_customer_etl_chain(
+    #     self,
+    #     customer_org_name: str,
+    #     datalake_bucket_name: str,
+    #     s3_folder_deleter_lambda: lambda_.Function,
+    #     etl_lambda: lambda_.Function,
+    # ):
+    #     customer_object_etl_chains: List[sfn.Chain] = [
+    #         self.make_customer_object_etl_chain(
+    #             customer_org_name=customer_org_name,
+    #             sf_object_name=sf_object_name,
+    #             datalake_bucket_name=datalake_bucket_name,
+    #             s3_folder_deleter_lambda=s3_folder_deleter_lambda,
+    #             etl_lambda=etl_lambda,
+    #         )
+    #         for sf_object_name in get_sf_object_names()
+    #     ]
+
+    #     parallel = sfn.Parallel(
+    #         self,
+    #         self.namer("etl-for-all-customer-objects"),
+    #     )
+
+    #     for customer_object_etl_chain in customer_object_etl_chains:
+    #         parallel.branch(customer_object_etl_chain)
+
+    #     return parallel
+
+    # def make_customer_object_etl_chain(
+    #     self,
+    #     customer_org_name: str,
+    #     sf_object_name: str,
+    #     s3_folder_deleter_lambda: lambda_.Function,
+    #     etl_lambda: lambda_.Function,
+    #     datalake_bucket_name: str,
+    # ) -> sfn.Chain:
+    #     customer__raw_obj__s3_folder = f"{customer_org_name}/{sf_object_name}_raw/"
+    #     # delete the old raw data
+    #     delete_raw_object_data_from_s3 = sfn_tasks.LambdaInvoke(
+    #         self,
+    #         self.name_by_sf_obj(sf_object_name, "delete-raw-obj-s3-folder"),
+    #         lambda_function=s3_folder_deleter_lambda,
+    #         comment=f"Delete folder {customer__raw_obj__s3_folder}",
+    #         payload=sfn.TaskInput.from_object(
+    #             {
+    #                 "s3_bucket_name": datalake_bucket_name,
+    #                 "prefix_to_delete": customer__raw_obj__s3_folder,
+    #             },
+    #         ),
+    #     )
+
+    #     # etl new raw data
+    #     etl_raw_customer_obj_data = sfn_tasks.LambdaInvoke(
+    #         self,
+    #         self.name_by_sf_obj(sf_object_name, "etl-raw-data"),
+    #         lambda_function=etl_lambda,
+    #         comment=f"ETL {customer_org_name}'s {sf_object_name} data into s3://{datalake_bucket_name}/{customer__raw_obj__s3_folder}",
+    #         payload=sfn.TaskInput.from_object(
+    #             {
+    #                 "customer_org_name": customer_org_name,
+    #                 "salesforce_object_name": sf_object_name,
+    #             }
+    #         ),
+    #     )
+
+    #     clean_data__select_stmt: str = make__clean_sf_obj_table__query(
+    #         customer_org_name=customer_org_name, sf_object=sf_object_name
+    #     )
+    #     create_or_replace__clean_sf_obj__table = create_or_replace_physical_table(
+    #         scope=self,
+    #         select_stmt=clean_data__select_stmt,
+    #         table_name=sf_object_name,
+    #         customer_org_name=customer_org_name,
+    #         datalake_bucket_name=datalake_bucket_name,
+    #         s3_folder_deleter_lambda=s3_folder_deleter_lambda,
+    #     )
+
+    #     return (
+    #         # 1
+    #         delete_raw_object_data_from_s3
+    #         # 2
+    #         .next(etl_raw_customer_obj_data)
+    #         # 3
+    #         .next(create_or_replace__clean_sf_obj__table)
+    #     )
+
+    # def make__pillar_one_query__state(
+    #     self,
+    #     customer_org_name: str,
+    #     datalake_bucket_name: str,
+    #     s3_folder_deleter_lambda: lambda_.Function,
+    # ) -> sfn.Parallel:
+
+    #     select__pillar_one_data__stmt: str = make__pillar_one__select_stmt(customer_org_name=customer_org_name)
+    #     create_or_replace_pillar_one_table: sfn.Parallel = create_or_replace_physical_table(
+    #         scope=self,
+    #         customer_org_name=customer_org_name,
+    #         datalake_bucket_name=datalake_bucket_name,
+    #         s3_folder_deleter_lambda=s3_folder_deleter_lambda,
+    #         select_stmt=select__pillar_one_data__stmt,
+    #         table_name=PILLAR_ONE_QUERY_INFO.athena_table_name,
+    #     )
+
+    #     return create_or_replace_pillar_one_table
+
+    # def make__opportunity_field_history__state(
+    #     self,
+    #     customer_org_name: str,
+    #     datalake_bucket_name: str,
+    #     s3_folder_deleter_lambda: lambda_.Function,
+    # ) -> sfn.Parallel:
+
+    #     select__opportunity_field_history__stmt: str = make__opp_field_history__select_stmt(
+    #         customer_org_name=customer_org_name
+    #     )
+    #     create_or_replace_opportunity_field_history_table: sfn.Parallel = create_or_replace_physical_table(
+    #         scope=self,
+    #         customer_org_name=customer_org_name,
+    #         datalake_bucket_name=datalake_bucket_name,
+    #         s3_folder_deleter_lambda=s3_folder_deleter_lambda,
+    #         select_stmt=select__opportunity_field_history__stmt,
+    #         table_name=OPP_HISTORY_QUERY_INFO.athena_table_name,
+    #     )
+
+    #     return create_or_replace_opportunity_field_history_table
+
+    # def grant_permissions_to_state_machine(self, state_machine_role: iam.Role, datalake_bucket_name: str):
+    #     state_machine_role.attach_inline_policy(
+    #         policy=iam.Policy(
+    #             self,
+    #             "allow-customer-athena-db-read-write",
+    #             document=iam.PolicyDocument(
+    #                 statements=[
+    #                     iam.PolicyStatement(
+    #                         actions=["glue:*"],
+    #                         resources=[
+    #                             f"arn:aws:glue:{self.region}:{self.account}:database/*",
+    #                             f"arn:aws:glue:{self.region}:{self.account}:table/*",
+    #                             # f"arn:aws:glue:{self.region}:{self.account}:database/{customer_org_name}",
+    #                             # f"arn:aws:glue:{self.region}:{self.account}:table/{customer_org_name}/*",
+    #                         ],
+    #                         effect=iam.Effect.ALLOW,
+    #                     )
+    #                 ]
+    #             ),
+    #         )
+    #     )
+
+    #     grant_read_write_access_to_bucket(self, role=state_machine_role, bucket_name=datalake_bucket_name)

--- a/awscdk-minecraft/src/cdk_minecraft/stack.py
+++ b/awscdk-minecraft/src/cdk_minecraft/stack.py
@@ -7,6 +7,7 @@ from cdk_minecraft.deploy_server_batch_job.job_definition import (
     make_minecraft_ec2_deployment__batch_job_definition,
 )
 from cdk_minecraft.deploy_server_batch_job.job_queue import BatchJobQueue
+from cdk_minecraft.deploy_server_batch_job.state_machine import ProvisionMinecraftServerStateMachine
 from constructs import Construct
 
 
@@ -43,6 +44,13 @@ class MinecraftPaasStack(Stack):
             )
         )
 
+        mc_deployment_state_machine = ProvisionMinecraftServerStateMachine(
+            self,
+            construct_id=f"{construct_id}ProvisionMcStateMachine",
+            job_queue_arn=job_queue.job_queue_arn,
+            deploy_or_destroy_mc_server_job_definition_arn=minecraft_server_deployer_job_definition.job_definition_arn,
+        )
+
         CfnOutput(
             self,
             id="MinecraftDeployerJobDefinitionArn",
@@ -62,4 +70,9 @@ class MinecraftPaasStack(Stack):
             self,
             id="MinecraftDeployerJobQueueName",
             value=job_queue.job_queue_name,
+        )
+        CfnOutput(
+            self,
+            id="StateMachineArn",
+            value=mc_deployment_state_machine.state_machine.state_machine_arn,
         )


### PR DESCRIPTION
this extends our stack in a few ways:
- adds EC2 instance to run the minecraft server
- adds IAM role for that EC2
- cloudwatch alarms for watching the load on the server
- cloudformation output (show us the IP of the provisioned machine)

basically everything an API will need to start/stop the server itself and provide a connection URL.

send
```
{
  "command": "deploy"
}
```
or `destroy`

to a step function and the EC2 instance will be created.

also testable via local docker-compose file in `resources/`

still to-do:
- restore state by grabbing files from s3 and mounting them as a volume when starting the docker minecraft service.
- preserve state by uploading snapshots of this volume to s3