### PR TITLE
added a lambda function to the state machine that validates the input…

### DIFF
--- a/awscdk-minecraft/setup.cfg
+++ b/awscdk-minecraft/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     aws-cdk-lib >=2.45.0, <3.0.0
     constructs >=10.0.5, <11.0.0
     aws-cdk.aws-batch-alpha
+    aws_cdk.aws_lambda_python_alpha
     aws_prototyping_sdk.static_website
 
 [options.packages.find]

--- a/awscdk-minecraft/src/cdk_minecraft/deploy_server_batch_job/state_machine.py
+++ b/awscdk-minecraft/src/cdk_minecraft/deploy_server_batch_job/state_machine.py
@@ -2,8 +2,12 @@
 from pathlib import Path
 from typing import Literal
 
+from aws_cdk import aws_lambda as lambda_
 from aws_cdk import aws_stepfunctions as sfn
 from aws_cdk import aws_stepfunctions_tasks as sfn_tasks
+from cdk_minecraft.deploy_server_batch_job.state_machine_input_validator.state_machine_input_validator_lambda import (
+    make_lambda_that_validates_input_of_the_provision_server_state_machine,
+)
 from constructs import Construct
 
 THIS_DIR = Path(__file__).parent
@@ -65,7 +69,7 @@ class ProvisionMinecraftServerStateMachine(Construct):
             )
         )
 
-        state_machine = (
+        state_machine = create__validate_input__state(scope=self, id_prefix=construct_id).next(
             sfn.Choice(
                 self,
                 id=self.namer("ChooseCdkDeployOrDestroy"),
@@ -143,215 +147,22 @@ def create__deploy_or_destroy__submit_batch_job_state(
 
     raise ValueError("Invalid command. ``command`` must be one of 'destroy' or 'deploy'")
 
-    # def make_state_machine(
-    #     self,
-    #     customer_org_name: str,
-    #     datalake_bucket_name: str,
-    #     etl_function: lambda_.Function,
-    #     s3_folder_deleter_function: lambda_.Function,
-    # ) -> sfn.StateMachine:
-    #     """Create the state machine (DAG) that does the ETL."""
-    #     state_machine = sfn.StateMachine(
-    #         self,
-    #         self.namer("etl-state-machine"),
-    #         definition=self.make__state_machine_definition(
-    #             customer_org_name=customer_org_name,
-    #             datalake_bucket_name=datalake_bucket_name,
-    #             etl_function=etl_function,
-    #             s3_folder_deleter_function=s3_folder_deleter_function,
-    #         ),
-    #     )
 
-    #     self.grant_permissions_to_state_machine(
-    #         state_machine_role=state_machine.role,
-    #         datalake_bucket_name=datalake_bucket_name,
-    #     )
+def create__validate_input__state(scope: Construct, id_prefix: str) -> sfn_tasks.LambdaInvoke:
+    """Return a task that validates the execution input of the provision server state machine."""
 
-    #     return state_machine
+    validate_input_fn: lambda_.Function = (
+        make_lambda_that_validates_input_of_the_provision_server_state_machine(scope=scope, id_prefix=id_prefix)
+    )
 
-    # def make__state_machine_definition(
-    #     self,
-    #     customer_org_name: str,
-    #     datalake_bucket_name: str,
-    #     etl_function: lambda_.Function,
-    #     s3_folder_deleter_function: lambda_.Function,
-    # ) -> sfn.IChainable:
-    #     """Define the entire DAG of states/tasks that will ELT data for a customer."""
-    #     etl_chain = self.make_customer_etl_chain(
-    #         customer_org_name=customer_org_name,
-    #         datalake_bucket_name=datalake_bucket_name,
-    #         etl_lambda=etl_function,
-    #         s3_folder_deleter_lambda=s3_folder_deleter_function,
-    #     )
-
-    #     pillar_one_chain = self.make__pillar_one_query__state(
-    #         customer_org_name=customer_org_name,
-    #         datalake_bucket_name=datalake_bucket_name,
-    #         s3_folder_deleter_lambda=s3_folder_deleter_function,
-    #     )
-
-    #     opportunity_field_history_chain = self.make__opportunity_field_history__state(
-    #         customer_org_name=customer_org_name,
-    #         datalake_bucket_name=datalake_bucket_name,
-    #         s3_folder_deleter_lambda=s3_folder_deleter_function,
-    #     )
-
-    #     post_clean_queries_parallel = sfn.Parallel(
-    #         self,
-    #         self.namer("post-clean-queries"),
-    #     )
-
-    #     post_clean_queries_parallel.branch(pillar_one_chain)
-    #     post_clean_queries_parallel.branch(opportunity_field_history_chain)
-
-    #     return etl_chain.next(post_clean_queries_parallel)
-
-    # def make_customer_etl_chain(
-    #     self,
-    #     customer_org_name: str,
-    #     datalake_bucket_name: str,
-    #     s3_folder_deleter_lambda: lambda_.Function,
-    #     etl_lambda: lambda_.Function,
-    # ):
-    #     customer_object_etl_chains: List[sfn.Chain] = [
-    #         self.make_customer_object_etl_chain(
-    #             customer_org_name=customer_org_name,
-    #             sf_object_name=sf_object_name,
-    #             datalake_bucket_name=datalake_bucket_name,
-    #             s3_folder_deleter_lambda=s3_folder_deleter_lambda,
-    #             etl_lambda=etl_lambda,
-    #         )
-    #         for sf_object_name in get_sf_object_names()
-    #     ]
-
-    #     parallel = sfn.Parallel(
-    #         self,
-    #         self.namer("etl-for-all-customer-objects"),
-    #     )
-
-    #     for customer_object_etl_chain in customer_object_etl_chains:
-    #         parallel.branch(customer_object_etl_chain)
-
-    #     return parallel
-
-    # def make_customer_object_etl_chain(
-    #     self,
-    #     customer_org_name: str,
-    #     sf_object_name: str,
-    #     s3_folder_deleter_lambda: lambda_.Function,
-    #     etl_lambda: lambda_.Function,
-    #     datalake_bucket_name: str,
-    # ) -> sfn.Chain:
-    #     customer__raw_obj__s3_folder = f"{customer_org_name}/{sf_object_name}_raw/"
-    #     # delete the old raw data
-    #     delete_raw_object_data_from_s3 = sfn_tasks.LambdaInvoke(
-    #         self,
-    #         self.name_by_sf_obj(sf_object_name, "delete-raw-obj-s3-folder"),
-    #         lambda_function=s3_folder_deleter_lambda,
-    #         comment=f"Delete folder {customer__raw_obj__s3_folder}",
-    #         payload=sfn.TaskInput.from_object(
-    #             {
-    #                 "s3_bucket_name": datalake_bucket_name,
-    #                 "prefix_to_delete": customer__raw_obj__s3_folder,
-    #             },
-    #         ),
-    #     )
-
-    #     # etl new raw data
-    #     etl_raw_customer_obj_data = sfn_tasks.LambdaInvoke(
-    #         self,
-    #         self.name_by_sf_obj(sf_object_name, "etl-raw-data"),
-    #         lambda_function=etl_lambda,
-    #         comment=f"ETL {customer_org_name}'s {sf_object_name} data into s3://{datalake_bucket_name}/{customer__raw_obj__s3_folder}",
-    #         payload=sfn.TaskInput.from_object(
-    #             {
-    #                 "customer_org_name": customer_org_name,
-    #                 "salesforce_object_name": sf_object_name,
-    #             }
-    #         ),
-    #     )
-
-    #     clean_data__select_stmt: str = make__clean_sf_obj_table__query(
-    #         customer_org_name=customer_org_name, sf_object=sf_object_name
-    #     )
-    #     create_or_replace__clean_sf_obj__table = create_or_replace_physical_table(
-    #         scope=self,
-    #         select_stmt=clean_data__select_stmt,
-    #         table_name=sf_object_name,
-    #         customer_org_name=customer_org_name,
-    #         datalake_bucket_name=datalake_bucket_name,
-    #         s3_folder_deleter_lambda=s3_folder_deleter_lambda,
-    #     )
-
-    #     return (
-    #         # 1
-    #         delete_raw_object_data_from_s3
-    #         # 2
-    #         .next(etl_raw_customer_obj_data)
-    #         # 3
-    #         .next(create_or_replace__clean_sf_obj__table)
-    #     )
-
-    # def make__pillar_one_query__state(
-    #     self,
-    #     customer_org_name: str,
-    #     datalake_bucket_name: str,
-    #     s3_folder_deleter_lambda: lambda_.Function,
-    # ) -> sfn.Parallel:
-
-    #     select__pillar_one_data__stmt: str = make__pillar_one__select_stmt(customer_org_name=customer_org_name)
-    #     create_or_replace_pillar_one_table: sfn.Parallel = create_or_replace_physical_table(
-    #         scope=self,
-    #         customer_org_name=customer_org_name,
-    #         datalake_bucket_name=datalake_bucket_name,
-    #         s3_folder_deleter_lambda=s3_folder_deleter_lambda,
-    #         select_stmt=select__pillar_one_data__stmt,
-    #         table_name=PILLAR_ONE_QUERY_INFO.athena_table_name,
-    #     )
-
-    #     return create_or_replace_pillar_one_table
-
-    # def make__opportunity_field_history__state(
-    #     self,
-    #     customer_org_name: str,
-    #     datalake_bucket_name: str,
-    #     s3_folder_deleter_lambda: lambda_.Function,
-    # ) -> sfn.Parallel:
-
-    #     select__opportunity_field_history__stmt: str = make__opp_field_history__select_stmt(
-    #         customer_org_name=customer_org_name
-    #     )
-    #     create_or_replace_opportunity_field_history_table: sfn.Parallel = create_or_replace_physical_table(
-    #         scope=self,
-    #         customer_org_name=customer_org_name,
-    #         datalake_bucket_name=datalake_bucket_name,
-    #         s3_folder_deleter_lambda=s3_folder_deleter_lambda,
-    #         select_stmt=select__opportunity_field_history__stmt,
-    #         table_name=OPP_HISTORY_QUERY_INFO.athena_table_name,
-    #     )
-
-    #     return create_or_replace_opportunity_field_history_table
-
-    # def grant_permissions_to_state_machine(self, state_machine_role: iam.Role, datalake_bucket_name: str):
-    #     state_machine_role.attach_inline_policy(
-    #         policy=iam.Policy(
-    #             self,
-    #             "allow-customer-athena-db-read-write",
-    #             document=iam.PolicyDocument(
-    #                 statements=[
-    #                     iam.PolicyStatement(
-    #                         actions=["glue:*"],
-    #                         resources=[
-    #                             f"arn:aws:glue:{self.region}:{self.account}:database/*",
-    #                             f"arn:aws:glue:{self.region}:{self.account}:table/*",
-    #                             # f"arn:aws:glue:{self.region}:{self.account}:database/{customer_org_name}",
-    #                             # f"arn:aws:glue:{self.region}:{self.account}:table/{customer_org_name}/*",
-    #                         ],
-    #                         effect=iam.Effect.ALLOW,
-    #                     )
-    #                 ]
-    #             ),
-    #         )
-    #     )
-
-    #     grant_read_write_access_to_bucket(self, role=state_machine_role, bucket_name=datalake_bucket_name)
+    # return a task that passes the entire input as the event in the validator lambda function
+    return sfn_tasks.LambdaInvoke(
+        scope=scope,
+        id=f"{id_prefix}ValidateInput",
+        lambda_function=validate_input_fn,
+        # payload=sfn.TaskInput.from_json_path_at("$"),
+        input_path="$",
+        output_path="$",
+        result_path="$",
+        payload_response_only=True,
+    )

--- a/awscdk-minecraft/src/cdk_minecraft/deploy_server_batch_job/state_machine_input_validator/resources/index.py
+++ b/awscdk-minecraft/src/cdk_minecraft/deploy_server_batch_job/state_machine_input_validator/resources/index.py
@@ -1,13 +1,17 @@
 from contextlib import contextmanager
 from datetime import datetime, timezone
+from pprint import pprint
 from typing import Dict, Literal, Optional
 
 from pydantic import BaseModel, validator
 
 
-def handler(event: Dict[str, str], context):
+def handler(event: Dict[str, str], context) -> Dict[str, str]:
     """Validate the ``event`` state machine input object."""
+    print("event: ")
+    pprint(event)
     ProvisionMinecraftServerStateMachineInput(**event)
+    return event
 
 
 class ProvisionMinecraftServerStateMachineInput(BaseModel):

--- a/awscdk-minecraft/src/cdk_minecraft/deploy_server_batch_job/state_machine_input_validator/state_machine_input_validator_lambda.py
+++ b/awscdk-minecraft/src/cdk_minecraft/deploy_server_batch_job/state_machine_input_validator/state_machine_input_validator_lambda.py
@@ -1,21 +1,35 @@
+from pathlib import Path
+
 import aws_cdk as cdk
 from aws_cdk import aws_lambda as lambda_
-from aws_cdk import aws_stepfunctions as sfn
+from aws_cdk import aws_lambda_python_alpha as lambda_python
 from constructs import Construct
 
-# construct
+THIS_DIR = Path(__file__).parent
+MC_SERVER_PROVISION_SFN__INPUT_VALIDATOR__SRC_DIR = THIS_DIR / "resources"
 
 
 def make_lambda_that_validates_input_of_the_provision_server_state_machine(
-    scope: Construct,
-) -> lambda_.Function:
+    scope: Construct, id_prefix: str
+) -> lambda_python.PythonFunction:
 
     # define the lambda function
-    return lambda_.Function(
+    return lambda_python.PythonFunction(
         scope,
-        "ProvisionMcServerInputValidator",
+        f"{id_prefix}ProvisionMcServerInputValidator",
+        entry=str(MC_SERVER_PROVISION_SFN__INPUT_VALIDATOR__SRC_DIR),
+        handler="handler",
+        index="index.py",
         runtime=lambda_.Runtime.PYTHON_3_8,
-        handler="index.handler",
-        code=lambda_.Code.from_asset("src/cdk_minecraft/deploy_server_batch_job"),
         timeout=cdk.Duration.seconds(30),
+        bundling=lambda_python.BundlingOptions(
+            image=cdk.DockerImage.from_registry(image="lambci/lambda:build-python3.8"),
+        )
+        # bundling=cdk.BundlingOptions(
+        #     # learn about this here:
+        #     # https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_lambda/README.html#bundling-asset-code
+        #     # Using this lambci image makes it so that dependencies with C-binaries compile correctly for the lambda runtime.
+        #     # The AWS CDK python images were not doing this. Relevant dependencies are: pandas, asyncpg, and psycogp2-binary.
+        #     image=cdk.DockerImage.from_registry(image="lambci/lambda:build-python3.8"),
+        # ),
     )


### PR DESCRIPTION
The last PR started work that this PR finishes. We added an AWS Lambda function to the step function DAG that validates that the input is correct. 

```json
{
    "command": "deploy"
}
```

and

```json
{
    "command": "destroy",
    "destroy_at_utc_time": "some ISO formatted UTC timestamp in the future"
}
```

are both considered valid inputs. Everything else is invalid. Eventually, we'll probably want to *not* require that `destroy_at_utc_time` would be set, and instead the server would delete right away, rather than in the future. That would be important for instantly stopping the server.

Here's the new state machine.

<img width="1139" alt="image" src="https://user-images.githubusercontent.com/32227767/209093224-3369f5c3-081e-4a21-a8d0-0c9a1419f408.png">

The lambda function handler has some test cases inside. We didn't use a python testing framework for these. I skipped that because I didn't want the overhead of putting the tests in another file and rigging up the PYTHONPATH to make it so those tests could import from the handler. Instead, the test cases are part of the `if __name__ == "__main__"` block in `index.py`.

Next up:

We'll add a `Wait` task to the state machine so that the "destroy" command waits until the given timestamp to actually destroy the server.
